### PR TITLE
Replace OpenTracing error logs with SignalFx tags

### DIFF
--- a/pymongo_opentracing/tracing.py
+++ b/pymongo_opentracing/tracing.py
@@ -53,7 +53,16 @@ class CommandTracing(pymongo.monitoring.CommandListener):
         if scope is None:
             return
         span = scope.span
-        span.set_tag(tags.ERROR, True)
         span.set_tag('event.failure', json.dumps(event.failure))
         span.set_tag('reported_duration', event.duration_micros)
+        span.set_tag(tags.ERROR, True)
+
+        err_msg = event.failure.get('errmsg')
+        if err_msg:
+            span.set_tag('sfx.error.message', err_msg)
+
+        err_code = event.failure.get('codeName')
+        if err_code:
+            span.set_tag('sfx.error.kind', err_code)
+
         scope.close()

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -88,6 +88,10 @@ class TestCommandTracing(object):
         tracer = MockTracer()
         tracing = CommandTracing(tracer, span_tags=dict(one=123))
         event = MockEvent()
+        event.failure = {
+            'errmsg': 'error message',
+            'codeName': 'SomeError'
+        }
         tracing.started(event)
         scope = tracing._scopes.get('request_id')
         tracing.failed(event)
@@ -96,3 +100,5 @@ class TestCommandTracing(object):
         tags = scope.span.tags
         assert tags['event.failure'] == json.dumps(event.failure)
         assert tags['reported_duration'] == event.duration_micros
+        assert tags['sfx.error.message'] == event.failure['errmsg']
+        assert tags['sfx.error.kind'] == event.failure['codeName']


### PR DESCRIPTION
This PR changes how errors are recorded on spans. It uses the new
SignalFx semantic convention and records the errors as attributes
instead of logs.